### PR TITLE
Successful cases were falling through to authorizationFailure()

### DIFF
--- a/resource-server/src/main/java/com/okta/servlet/examples/resourceserver/OktaBearerFilter.java
+++ b/resource-server/src/main/java/com/okta/servlet/examples/resourceserver/OktaBearerFilter.java
@@ -74,6 +74,7 @@ public class OktaBearerFilter implements Filter {
 
                         // continue
                         chain.doFilter(request, response);
+                        return;
                     } catch (JwtVerificationException e) {
                         request.getServletContext().log("Invalid access token", e);
                     }


### PR DESCRIPTION
I was testing this today and was getting 401's with successful authentication.

The return is needed so that the function exists after the doFilter().  Otherwise, the accessToken is set on the request but sendError() will end up being called.