### PR TITLE
Enforce version `3.6.0` of `okio-jvm` in authn-servlet module

### DIFF
--- a/authn-servlet/pom.xml
+++ b/authn-servlet/pom.xml
@@ -84,6 +84,12 @@
             <version>2.15.1</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-jvm</artifactId>
+            <version>3.6.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>apache-jstl</artifactId>
             <version>10.0.15</version>


### PR DESCRIPTION
OKTA-635915